### PR TITLE
Remove use of HG

### DIFF
--- a/Makefile.xcp
+++ b/Makefile.xcp
@@ -19,3 +19,6 @@ srpm:
 	git archive --prefix=xapi-libs-0/ --format=tar HEAD | bzip2 -z > $(RPM_SOURCEDIR)/xapi-libs-0.tar.bz2  # xen-api-libs/Makefile.xcp
 	rpmbuild --define "XEN_RELEASE $(XEN_RELEASE)" -bs --nodeps xapi-libs.spec
 
+.PHONY: rpm
+rpm: srpm
+	rpmbuild -bb xapi-libs.spec


### PR DESCRIPTION
This removes the use of HG in the XCP makefile, replacing it with git.

I also removed a dependency on ocaml-camlp4 since this is included in the ocaml packet.
