### PR TITLE
Add Python-like range function

### DIFF
--- a/stdext/listext.ml
+++ b/stdext/listext.ml
@@ -209,4 +209,11 @@ let filter_map f list =
 let restrict_with_default default keys al =
 	make_assoc (fun k -> assoc_default k al default) keys
 
+let range lower =
+	let rec aux accu upper =
+		if lower >= upper
+		then accu
+		else aux (upper-1::accu) (upper-1) in
+	aux []
+
 end

--- a/stdext/listext.mli
+++ b/stdext/listext.mli
@@ -195,4 +195,8 @@ sig
 	    from [keys] to previous values for [keys] in [al]. If a key is not found
 	    in [al], the [default] is used. *)
 	val restrict_with_default : 'v -> 'k list -> ('k * 'v) list -> ('k * 'v) list
+
+	(** range lower upper = [lower; lower + 1; ...; upper - 1]
+	    Returns the empty list if lower >= upper. *)
+	val range : int -> int -> int list
 end


### PR DESCRIPTION
The `range' functional allows the use of e.g. List.map, where we tended to use
for-loops.

(range lower upper) generates a list of numbers in an half-open
interval.  I.e. the lower boundary is included, the upper isn't.  That makes it
easy to reason about concatenating ranges.

Signed-off-by: Matthias Goergens matthias.goergens@gmail.com
