### PR TITLE
CA-48650: xe {vm|host}-data-source-forget accept invalid data-source name without warning (xen-api-libs part)

### DIFF
--- a/stdext/arrayext.ml
+++ b/stdext/arrayext.ml
@@ -39,7 +39,21 @@ let fold_right2 f a b x =
 	done;
 	!r
 
+let index e a =
+	let len = length a in
+	let rec check i =
+		if len <= i then -1
+		else if get a i = e then i
+		else check (i + 1)
+	in check 0
+
 let inner fold_left2 base f l1 l2 g =
 	fold_left2 (fun accu e1 e2 -> g accu (f e1 e2)) base l1 l2
-end
 
+let mem e a =
+	index e a <> -1
+
+let remove n a =
+	append (sub a 0 n) (sub a (n+1) (length a - n - 1))
+
+end

--- a/stdext/arrayext.mli
+++ b/stdext/arrayext.mli
@@ -52,8 +52,17 @@ sig
 	val fold_right2 :
 		('a -> 'b -> 'c -> 'c) -> 'a array -> 'b array -> 'c -> 'c
 
+	(** Get first index of an element in the array, or -1. *)
+	val index : 'a -> 'a array -> int
+
 	(** Compute the inner product of two arrays. *)
 	val inner :
 		(('a -> 'b -> 'c -> 'd) -> 'e -> 'f -> 'g -> 'h) ->
 		'e -> ('b -> 'c -> 'i) -> 'f -> 'g -> ('a -> 'i -> 'd) -> 'h
+
+	(** Check if an element appears in the array. *)
+	val mem : 'a -> 'a array -> bool
+
+	(** Remove the element at specified position from the array. *)
+	val remove : int -> 'a array -> 'a array
 end


### PR DESCRIPTION
This change should be merged before the corresponding change to `xen-api`. It simply introduces a few helper functions, which make the change to `xen-api` cleaner.

The first commit is a white space change only:

```
~/myrepos/xen-api-libs$ git checkout 62e73dcabc6d1fdcb1dcf151855cbe7cd478ffd5
~/myrepos/xen-api-libs$ camlp4 -parser o -printer o -no_comments stdext/arrayext.mli | md5sum
939193afa94e3e6df7c3cca70497aa8a  -
~/myrepos/xen-api-libs$ git checkout a4a8072879a5c56160ae400fa00e3c101bb247c5
939193afa94e3e6df7c3cca70497aa8a  -
```

The second commit adds Array functions `index`, `mem`, and `remove`.
