### PR TITLE
CA-65181: Allow arbitrary keys for syslog entries

### DIFF
--- a/forking_executioner/fe_main.ml
+++ b/forking_executioner/fe_main.ml
@@ -25,7 +25,7 @@ let setup sock cmdargs id_to_fd_map syslog_stdout env =
 	Child.cmdargs=cmdargs; 
 	env=env;
 	id_to_fd_map=id_to_fd_map; 
-	syslog_stdout=syslog_stdout;
+	syslog_stdout={Child.enabled=syslog_stdout.Fe.enabled; Child.key=syslog_stdout.Fe.key};
 	ids_received=[];
 	fd_sock2=None;
 	finished=false;

--- a/stdext/fe.ml
+++ b/stdext/fe.ml
@@ -1,9 +1,13 @@
+type syslog_stdout_t = {
+  enabled : bool;
+  key : string option;
+}
 
-type setup_cmd = {
+and setup_cmd = {
   cmdargs : string list;
   env : string list;
   id_to_fd_map : (string * int option) list;
-  syslog_stdout : bool;
+  syslog_stdout : syslog_stdout_t;
 } 
 
 and setup_response = {

--- a/stdext/fe_cli.ml
+++ b/stdext/fe_cli.ml
@@ -8,7 +8,7 @@ let _ =
 		exit 1
   | cmd :: args ->
 		try
-		  let out, err = Forkhelpers.execute_command_get_output ~syslog_stdout:false cmd args (* TODO *) in
+		  let out, err = Forkhelpers.execute_command_get_output ~syslog_stdout:Forkhelpers.NoSyslogging cmd args in
 		  Printf.printf "stdout=[%s]\n" out;
 		  Printf.printf "stderr=[%s]\n" err;
 		  exit 0

--- a/stdext/forkhelpers.ml
+++ b/stdext/forkhelpers.ml
@@ -86,9 +86,14 @@ exception Spawn_internal_error of string * string * Unix.process_status
 
 let id = ref 0 
 
+type syslog_stdout_t =
+  | NoSyslogging
+  | Syslog_DefaultKey
+  | Syslog_WithKey of string
+
 (** Safe function which forks a command, closing all fds except a whitelist and
     having performed some fd operations in the child *)
-let safe_close_and_exec ?env stdin stdout stderr (fds: (string * Unix.file_descr) list) ?(syslog_stdout=false)
+let safe_close_and_exec ?env stdin stdout stderr (fds: (string * Unix.file_descr) list) ?(syslog_stdout=NoSyslogging)
     (cmd: string) (args: string list) =
 
   let sock = Fecomms.open_unix_domain_sock_client "/var/xapi/forker/main" in
@@ -125,6 +130,11 @@ let safe_close_and_exec ?env stdin stdout stderr (fds: (string * Unix.file_descr
       |	Some e -> e
       | None -> [| "PATH=" ^ (String.concat ":" default_path) |]
     in
+    let syslog_stdout = match syslog_stdout with
+      | NoSyslogging -> {Fe.enabled=false; Fe.key=None}
+      | Syslog_DefaultKey -> {Fe.enabled=true; Fe.key=None}
+      | Syslog_WithKey k -> {Fe.enabled=true; Fe.key=Some k}
+    in
     Fecomms.write_raw_rpc sock (Fe.Setup {Fe.cmdargs=(cmd::args); env=(Array.to_list env); id_to_fd_map = id_to_fd_map; syslog_stdout = syslog_stdout});
 
     let response = Fecomms.read_raw_rpc sock in
@@ -151,7 +161,7 @@ let safe_close_and_exec ?env stdin stdout stderr (fds: (string * Unix.file_descr
     close_fds
 
 
-let execute_command_get_output ?env ?(syslog_stdout=false) cmd args =
+let execute_command_get_output ?env ?(syslog_stdout=NoSyslogging) cmd args =
   match with_logfile_fd "execute_command_get_out" (fun out_fd ->
     with_logfile_fd "execute_command_get_err" (fun err_fd ->
       let (sock,pid) = safe_close_and_exec ?env None (Some out_fd) (Some err_fd) [] ~syslog_stdout cmd args in

--- a/stdext/forkhelpers.mli
+++ b/stdext/forkhelpers.mli
@@ -34,10 +34,15 @@
 
 (** {2 High-level interface } *)
 
+type syslog_stdout_t =
+  | NoSyslogging
+  | Syslog_DefaultKey
+  | Syslog_WithKey of string
+
 (** [execute_command_get_output cmd args] runs [cmd args] and returns (stdout, stderr)
 	on success (exit 0). On failure this raises 
     [Spawn_internal_error(stderr, stdout, Unix.process_status)] *)
-val execute_command_get_output : ?env:string array -> ?syslog_stdout:bool -> string -> string list -> string * string
+val execute_command_get_output : ?env:string array -> ?syslog_stdout:syslog_stdout_t -> string -> string list -> string * string
 
 (** Thrown by [execute_command_get_output] if the subprocess exits with a non-zero exit code *)
 exception Spawn_internal_error of string * string * Unix.process_status
@@ -63,7 +68,7 @@ exception Subprocess_killed of int
 	with the optional [stdin], [stdout] and [stderr] file descriptors (or /dev/null if not
 	specified) and with any key from [id_to_fd_list] in [args] replaced by the integer
 	value of the file descriptor in the final process. *)
-val safe_close_and_exec : ?env:string array -> Unix.file_descr option -> Unix.file_descr option -> Unix.file_descr option -> (string * Unix.file_descr) list -> ?syslog_stdout:bool -> string -> string list -> pidty
+val safe_close_and_exec : ?env:string array -> Unix.file_descr option -> Unix.file_descr option -> Unix.file_descr option -> (string * Unix.file_descr) list -> ?syslog_stdout:syslog_stdout_t -> string -> string list -> pidty
 
 (** [waitpid p] returns the (pid, Unix.process_status) *)
 val waitpid : pidty -> (int * Unix.process_status)


### PR DESCRIPTION
Currently, syslog entries produced by the fe daemon are prefixed with the process name and the pid. For qemu-dm processes, we also want the domid. These changes add the facility to provide arbitrary text to use as the syslog key.
