### PR TITLE
CA-65202: Fix HTTP parser: strip "HTTP/" from the HTTP request version an

### DIFF
--- a/http-svr/http.ml
+++ b/http-svr/http.ml
@@ -227,11 +227,18 @@ module Request = struct
 		| [ m; uri; version ] ->
 			(* Request-Line   = Method SP Request-URI SP HTTP-Version CRLF *)
 			let uri, query = parse_uri uri in
-			{ m = method_t_of_string m; uri = uri; query = query;
-			content_length = None; transfer_encoding = None;
-			version = version; cookie = []; auth = None; task = None;
-			subtask_of = None; content_type = None; user_agent = None;
-			close=false; additional_headers=[]; body = None }
+			(* strip the "HTTP/" prefix from the version string *)
+            begin match String.split ~limit:2 '/' version with
+                | [ _; version ] ->
+                    { m = method_t_of_string m; uri = uri; query = query;
+                    content_length = None; transfer_encoding = None;
+                    version = version; cookie = []; auth = None; task = None;
+                    subtask_of = None; content_type = None; user_agent = None;
+                    close=false; additional_headers=[]; body = None }
+                | _ ->
+                    error "Failed to parse: %s" x;
+                    raise Http_parse_failure
+            end
 		| _ -> raise Http_parse_failure
 
 	let to_string x =

--- a/http-svr/http_svr.ml
+++ b/http-svr/http_svr.ml
@@ -197,7 +197,9 @@ let request_of_bio_exn ic =
 					| k when k = subtask_of_hdr -> subtask_of := Some v; true
 					| k when k = content_type_hdr -> content_type := Some v; true
 					| k when k = user_agent_hdr -> user_agent := Some v; true
-					| k when k = connection_hdr && String.lowercase v = "close" -> req.Request.close <- true; true
+                    | k when k = connection_hdr ->
+                        req.Request.close <- String.lowercase v = "close";
+                        true
 					| _ -> false in
 				if not absorbed && left <= 0 then raise Too_many_headers;
 				if absorbed


### PR DESCRIPTION
CA-65202: Fix HTTP parser: strip "HTTP/" from the HTTP request version and avoid duplicating the "Connection:" header

Signed-off-by: David Scott dave.scott@eu.citrix.com
