### PR TITLE
CA-66148: fix broken HTTP version check

### DIFF
--- a/http-svr/http_svr.ml
+++ b/http-svr/http_svr.ml
@@ -171,7 +171,7 @@ let request_of_bio_exn ic =
 
 	(* Default for HTTP/1.1 is persistent connections. Anything else closes *)
 	(* the channel as soon as the request is processed *)
-	if req.Request.version <> "HTTP/1.1" then req.Request.close <- true;
+	if req.Request.version <> "1.1" then req.Request.close <- true;
 
 	let rec read_rest_of_headers left =
 		let cl_hdr = String.lowercase Http.Hdr.content_length in


### PR DESCRIPTION
This caused HTTP/1.1 requests without a Connection: header to default to "close" rather than "keep-alive", breaking unupgraded slaves talking to an upgraded master.

Signed-off-by: David Scott dave.scott@eu.citrix.com
