### PR TITLE
Expose the rpc_of_t and t_of_rpc methods in the Http.Request module

### DIFF
--- a/http-svr/http.mli
+++ b/http-svr/http.mli
@@ -51,6 +51,9 @@ module Request : sig
 		body: string option;
 	}
 
+	val rpc_of_t : t -> Rpc.t
+	val t_of_rpc : Rpc.t -> t
+	  
 	val empty: t
 
 	(** [make] is the standard constructor for [t] *)


### PR DESCRIPTION
Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
