### PR TITLE
Since the Http server is a mutable record, the constructor needs to creat

### DIFF
--- a/http-svr/http_svr.ml
+++ b/http-svr/http_svr.ml
@@ -173,7 +173,7 @@ module Server = struct
 		mutable use_fastpath: bool;
 	}
 
-	let empty = {
+	let empty () = {
 		handlers = MethodMap.empty;
 		use_fastpath = false;
 	}

--- a/http-svr/http_svr.mli
+++ b/http-svr/http_svr.mli
@@ -36,7 +36,7 @@ module Server : sig
 	type t
 
 	(** An HTTP server which sends back a default error response to every request *)
-	val empty: t
+	val empty: unit -> t
 
 	(** [add_handler x m uri h] adds handler [h] to server [x] to serve all requests with
 		method [m] for URI prefix [uri] *)

--- a/http-svr/test_server.ml
+++ b/http-svr/test_server.ml
@@ -13,7 +13,7 @@ let _ =
 	] (fun x -> Printf.fprintf stderr "Ignoring unexpected argument: %s\n" x)
 		"A simple test HTTP server";
 	let open Http_svr in
-	let server = Server.empty in
+	let server = Server.empty () in
 	if !use_fastpath then Server.enable_fastpath server;
 
 	Server.add_handler server Http.Get "/stop" (FdIO


### PR DESCRIPTION
Since the Http server is a mutable record, the constructor needs to create a fresh instance each time, or else all servers will share the same fields.

Signed-off-by: David Scott dave.scott@eu.citrix.com
