### PR TITLE
rpc-light.idl: remove the catch-all RpcFailure(INTERNAL_ERROR): allow imp

### DIFF
--- a/rpc-light/p4_idl.ml
+++ b/rpc-light/p4_idl.ml
@@ -276,10 +276,7 @@ struct
 					with
 						[ RpcFailure (x,y) -> 
 							{ Rpc.success = False;
-							  Rpc.contents = rpc_of_failure (x,y); }
-						| e -> 
-							{ Rpc.success = False;
-							  Rpc.contents = rpc_of_failure ("INTERNAL_ERROR",[]) } ];
+							  Rpc.contents = rpc_of_failure (x,y); } ];
 			end >>
 
 


### PR DESCRIPTION
rpc-light.idl: remove the catch-all RpcFailure(INTERNAL_ERROR): allow implementations to handle errors how they see fit.

It was never useful to see one of these errors because they contain no useful information. If we let the exception propagate then the caller (in the RPC unmarshal/process/marshal function) can do the 'right thing' in an application-specific way.

Signed-off-by: David Scott dave.scott@eu.citrix.com
