### PR TITLE
Merge upstream rpc-light fix

### DIFF
--- a/rpc-light/jsonrpc.ml
+++ b/rpc-light/jsonrpc.ml
@@ -435,7 +435,6 @@ module Parser = struct
 		| Json_parse_incomplete of parse_state
 
 	let parse state str =
-		begin try
 			while get_parse_result state = None do
 				parse_char state (str ());
 				(* This is here instead of inside parse_char since
@@ -444,7 +443,6 @@ module Parser = struct
 				*)
 				state.num_chars_parsed <- state.num_chars_parsed + 1;
 			done;
-		with _ -> () end;
 		match get_parse_result state with
 		| Some v -> Json_value v
 		| None -> Json_parse_incomplete state


### PR DESCRIPTION
If the json becomes corrupted then it can trigger an infinite loop in the parser.
