### PR TITLE
Speed-up HTTP header processing by allowing an extra "frame" header to be

### DIFF
--- a/http-svr/http_svr.mli
+++ b/http-svr/http_svr.mli
@@ -27,6 +27,7 @@ module Stats : sig
 	type t = {
 		mutable n_requests: int;    (** Total number of requests processed *)
 		mutable n_connections: int; (** Total number of connections accepted *)
+		mutable n_framed: int;      (** using the more efficient framed protocol *)
 	}
 end
 
@@ -82,17 +83,15 @@ val read_chunked_encoding : Http.Request.t -> Buf_io.t -> string Http.ll
 
 val response_fct :
   Http.Request.t ->
-  ?hdrs:string list ->
+  ?hdrs:(string * string) list ->
   Unix.file_descr -> int64 -> (Unix.file_descr -> unit) -> unit
 
 val response_str :
-  Http.Request.t -> ?hdrs:string list -> Unix.file_descr -> string -> unit
-val response_missing : ?hdrs:string list -> Unix.file_descr -> string -> unit
+  Http.Request.t -> ?hdrs:(string * string) list -> Unix.file_descr -> string -> unit
+val response_missing : ?hdrs:(string * string) list -> Unix.file_descr -> string -> unit
 val response_unauthorised : ?req:Http.Request.t -> string -> Unix.file_descr -> unit
 val response_forbidden : ?req:Http.Request.t -> Unix.file_descr -> unit
-val response_file :
-  ?hdrs:'a list ->
-  ?mime_content_type:string -> Unix.file_descr -> string -> unit
+val response_file : ?mime_content_type:string -> Unix.file_descr -> string -> unit
 val respond_to_options : Http.Request.t -> Unix.file_descr -> unit
 
 val headers : Unix.file_descr -> string list -> unit

--- a/http-svr/xmlrpc_client.ml
+++ b/http-svr/xmlrpc_client.ml
@@ -31,9 +31,9 @@ let connect ?session_id ?task_id ?subtask_of path =
 	Http.Request.make ~user_agent ~version:"1.0" ~keep_alive:true ~cookie ?subtask_of
 		Http.Connect path
 
-let xmlrpc ?version ?keep_alive ?task_id ?cookie ?length ?subtask_of ?body path =
+let xmlrpc ?frame ?version ?keep_alive ?task_id ?cookie ?length ?subtask_of ?body path =
 	let headers = Opt.map (fun x -> [ Http.Hdr.task_id, x ]) task_id in
-	Http.Request.make ~user_agent ?version ?keep_alive ?cookie ?headers ?length ?subtask_of ?body
+	Http.Request.make ~user_agent ?frame ?version ?keep_alive ?cookie ?headers ?length ?subtask_of ?body
 		Http.Post path
 
 (** Thrown when ECONNRESET is caught which suggests the remote crashed or restarted *)

--- a/http-svr/xmlrpc_client.mli
+++ b/http-svr/xmlrpc_client.mli
@@ -50,7 +50,7 @@ val with_transport : transport -> (Unix.file_descr -> 'a) -> 'a
 val with_http : Http.Request.t -> (Http.Response.t * Unix.file_descr -> 'a) -> Unix.file_descr -> 'a
 
 (** Returns an HTTP.Request.t representing an XMLRPC request *)
-val xmlrpc: ?version:string -> ?keep_alive:bool -> ?task_id:string -> ?cookie:(string*string) list -> ?length:int64 -> ?subtask_of:string -> ?body:string -> string -> Http.Request.t
+val xmlrpc: ?frame:bool -> ?version:string -> ?keep_alive:bool -> ?task_id:string -> ?cookie:(string*string) list -> ?length:int64 -> ?subtask_of:string -> ?body:string -> string -> Http.Request.t
 
 (** Returns an HTTP.Request.t representing an HTTP CONNECT *)
 val connect: ?session_id:string -> ?task_id:string -> ?subtask_of:string -> string -> Http.Request.t


### PR DESCRIPTION
Speed-up HTTP header processing by allowing an extra "frame" header to be added before the HTTP header, which contains the HTTP header length.

Signed-off-by: David Scott dave.scott@eu.citrix.com
