### PR TITLE
[http-client]: add a URL parser (Http.Url.of_string) and make it easy to...

### DIFF
--- a/http-svr/http.mli
+++ b/http-svr/http.mli
@@ -76,7 +76,7 @@ module Request : sig
 	val empty: t
 
 	(** [make] is the standard constructor for [t] *)
-	val make: ?frame:bool -> ?version:string -> ?keep_alive:bool -> ?accept:string -> ?cookie:(string*string) list -> ?length:int64 -> ?subtask_of:string -> ?body:string -> ?headers:(string*string) list -> ?content_type:string -> user_agent:string -> method_t -> string -> t
+	val make: ?frame:bool -> ?version:string -> ?keep_alive:bool -> ?accept:string -> ?cookie:(string*string) list -> ?length:int64 -> ?auth:authorization -> ?subtask_of:string -> ?body:string -> ?headers:(string*string) list -> ?content_type:string -> user_agent:string -> method_t -> string -> t
 
 	(** [get_version t] returns the HTTP protocol version *)
 	val get_version: t -> string
@@ -166,3 +166,25 @@ val urlencode : string -> string
 
 type 'a ll = End | Item of 'a * (unit -> 'a ll)
 val ll_iter : ('a -> unit) -> 'a ll -> unit
+
+module Url : sig
+	type http = {
+		host: string;
+		auth: authorization option;
+		port: int option;
+		ssl: bool;
+	}
+	type file = {
+		path: string;
+	}
+
+	type t =
+		| Http of http * string
+		| File of file * string
+
+	val of_string: string -> t
+
+	val uri_of: t -> string
+
+	val auth_of: t -> authorization option
+end

--- a/http-svr/http_client.ml
+++ b/http-svr/http_client.ml
@@ -179,4 +179,3 @@ let rpc ?(use_fastpath=false) (fd: Unix.file_descr) request f =
 (*	Printf.printf "request = [%s]" (Http.Request.to_wire_string request);*)
 	http_rpc_send_query fd request;
 	f (http_rpc_recv_response use_fastpath (Http.Request.to_string request) fd) fd
-

--- a/http-svr/http_test.ml
+++ b/http-svr/http_test.ml
@@ -94,6 +94,41 @@ let test_radix_tree2 _ =
 	if List.length all <> (List.length test_strings)
 	then failwith "fold"
 
+let test_url _ =
+	let open Http in
+	let open Http.Url in
+	begin match of_string "file:/var/xapi/storage" with
+		| File ({ path = "/var/xapi/storage" }, "/") -> ()
+		| _ -> assert false
+	end;
+	begin match of_string "http://root:foo@localhost" with
+		| Http (t, "/") ->
+			assert (t.auth = Some(Basic("root", "foo")));
+			assert (t.ssl = false);
+			assert (t.host = "localhost");
+		| _ -> assert false
+	end;
+	begin match of_string "https://google.com/gmail" with
+		| Http (t, "/gmail") ->
+			assert (t.ssl = true);
+			assert (t.host = "google.com");
+		| _ -> assert false
+	end;
+	begin match of_string "https://xapi.xen.org/services/SM" with
+		| Http (t, "/services/SM") ->
+			assert (t.ssl = true);
+			assert (t.host = "xapi.xen.org");
+		| _ -> assert false
+	end;
+	begin match of_string "https://root:foo@xapi.xen.org:1234/services/SM" with
+		| Http (t, "/services/SM") ->
+			assert (t.auth = Some(Basic("root", "foo")));
+			assert (t.port = Some 1234);
+			assert (t.ssl = true);
+			assert (t.host = "xapi.xen.org");
+		| _ -> assert false
+	end
+
 let _ =
     let verbose = ref false in
     Arg.parse [
@@ -107,5 +142,6 @@ let _ =
             "accept_complex" >:: test_accept_complex;
 			"radix1" >:: test_radix_tree1;
 			"radix2" >:: test_radix_tree2;
+			"test_url" >:: test_url
 		] in
     run_test_tt ~verbose:!verbose suite

--- a/http-svr/xmlrpc_client.mli
+++ b/http-svr/xmlrpc_client.mli
@@ -37,6 +37,9 @@ type transport =
 	| TCP of string * int         (** Plain TCP/IP with a host, port *)
 	| SSL of SSL.t * string * int (** SSL over TCP/IP with a host, port *)
 
+(** [transport_of_url url] returns the transport associated with [url] *)
+val transport_of_url : Http.Url.t -> transport
+
 (** [string_of_transport t] returns a debug-friendly version of [t] *)
 val string_of_transport : transport -> string
 
@@ -50,7 +53,7 @@ val with_transport : transport -> (Unix.file_descr -> 'a) -> 'a
 val with_http : Http.Request.t -> (Http.Response.t * Unix.file_descr -> 'a) -> Unix.file_descr -> 'a
 
 (** Returns an HTTP.Request.t representing an XMLRPC request *)
-val xmlrpc: ?frame:bool -> ?version:string -> ?keep_alive:bool -> ?task_id:string -> ?cookie:(string*string) list -> ?length:int64 -> ?subtask_of:string -> ?body:string -> string -> Http.Request.t
+val xmlrpc: ?frame:bool -> ?version:string -> ?keep_alive:bool -> ?task_id:string -> ?cookie:(string*string) list -> ?length:int64 -> ?auth:Http.authorization -> ?subtask_of:string -> ?body:string -> string -> Http.Request.t
 
 (** Returns an HTTP.Request.t representing an HTTP CONNECT *)
 val connect: ?session_id:string -> ?task_id:string -> ?subtask_of:string -> string -> Http.Request.t


### PR DESCRIPTION
... "open" a URL via the existing "transport" mechanism.

The URL parser came from xen-api/.../sparse_dd but really should be shared.

Also add a set of URL parser unit tests.

Signed-off-by: David Scott dave.scott@eu.citrix.com
