### PR TITLE
Propagate network errors out of Http_client module

### DIFF
--- a/http-svr/xmlrpc_client.ml
+++ b/http-svr/xmlrpc_client.ml
@@ -245,8 +245,9 @@ let with_transport transport f = match transport with
 			)
 
 let with_http request f s =
-	Http_client.rpc s request
-		(fun response s -> f (response, s))
+	try
+		Http_client.rpc s request (fun response s -> f (response, s))
+	with Unix.Unix_error(Unix.ECONNRESET, _, _) -> raise Connection_reset
 
 let curry2 f (a, b) = f a b
 


### PR DESCRIPTION
... otherwise the callers (such as Xmlrpc_client) will get HTTP errors instead, hence lost the chance of diagnosing the network problems (e.g. stunnel issues).

Another possibility is to transform the Unix exception as module specific exception (or variant in the return type) and handle/wrap/propagate it in each upper layer (where necessary).

Signed-off-by: Zheng Li zheng.li@eu.citrix.com
