### PR TITLE
[rpc-light]: when marshalling XMLRPC, don't lose float precision

### DIFF
--- a/rpc-light/xmlrpc.ml
+++ b/rpc-light/xmlrpc.ml
@@ -72,7 +72,8 @@ let rec add_value f = function
 
 	| Float d ->
 		f "<value><double>";
-		f (Printf.sprintf "%g" d);
+		(* NB: "%g" loses a lot of precision (e.g. resulting in "1.32621e+09") *)
+		f (Printf.sprintf "%0.16g" d);
 		f "</double></value>"
 
 	| String s ->


### PR DESCRIPTION
Printf with "%g" will create strings like "1.32621e+09". If this was
a result from Unix.gettimeofday() then you've just rounded to the
nearest 5000 seconds (about an hour and a half)

Signed-off-by: David Scott dave.scott@eu.citrix.com
