### PR TITLE
Move fe up in the boot sequence

### DIFF
--- a/forking_executioner/init.d-fe
+++ b/forking_executioner/init.d-fe
@@ -2,7 +2,7 @@
 #
 # squeezed          Start/Stop the fork/exec daemon
 #
-# chkconfig: 2345 21 78
+# chkconfig: 2345 12 78
 # description: Fork/exec daemon
 # processname: fe
 # pidfile: /var/run/fe.pid


### PR DESCRIPTION
We need to start networkd earlier in the boot sequence, and networkd
need fe to be running.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
