### PR TITLE
Reduce logging in XML/RPC client

### DIFF
--- a/http-svr/xmlrpc_client.ml
+++ b/http-svr/xmlrpc_client.ml
@@ -185,7 +185,6 @@ let transport_of_url =
 
 let with_transport transport f = match transport with
 	| Unix path ->
-		debug "Attempting to open %s" path;
 		let fd = Unixext.open_connection_unix_fd path in
 		finally
 			(fun () -> f fd)


### PR DESCRIPTION
This removes the "Attempting to open..." log lines, which appear
on every XML/RPC call over a Unix domain socket. These lines are not
too useful, and with the gradual introduction of more and more calls
to helper daemons, they are getting too many.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
