### PR TITLE
Add Sandy/Ivy Bridge CPU models to the list for CPUID masking

### DIFF
--- a/cpuid/cpuid.ml
+++ b/cpuid/cpuid.ml
@@ -109,14 +109,14 @@ let read_features () =
 		
 (* Does this Intel CPU support "FlexMigration"? 
  * It's not sensibly documented, so check by model *)
-let has_flexmigration family model stepping = 
+let has_flexmigration family model stepping =
+	let fully_maskable_models =
+		[0x17l; 0x1dl; 0x1el; 0x1fl; 0x25l; 0x2al; 0x2cl; 0x2cl; 0x2dl; 0x2el; 0x2fl; 0x3al] in
 	if family <> 0x6l then
 		No
 	else if model = 0x1dl || (model = 0x17l && stepping >= 4l) then
 		Base
-	else if (model = 0x1al && stepping > 2l) ||
-		model = 0x1el || model = 0x25l || model = 0x2cl ||
-		model = 0x2el || model = 0x2fl then
+	else if (model = 0x1al && stepping > 2l) || List.mem model fully_maskable_models then
 		Full
 	else
 		No


### PR DESCRIPTION
Signed-off-by: Rob Hoes rob.hoes@citrix.com
