### PR TITLE
CA-83837: add 'Watch.has_fired: t -> bool'

### DIFF
--- a/xenstoreext/watch.ml
+++ b/xenstoreext/watch.ml
@@ -35,6 +35,10 @@ let result_map f = function
     of the paths change *)
 type 'a t = { paths: path list;
 	      evaluate: xs:Xs.xsh -> 'a result }
+
+let has_fired ~xs x = match x.evaluate ~xs with
+	| KeepWaiting -> false
+	| Result _ -> true
     
 let map f x = { x with evaluate = fun ~xs -> result_map f (x.evaluate ~xs) }
   

--- a/xenstoreext/watch.mli
+++ b/xenstoreext/watch.mli
@@ -34,6 +34,9 @@ val key_to_disappear : path -> unit t
 (** Represents a particular value appearing at a particular key *)
 val value_to_become : path -> string -> unit t
 
+(** True if the given watch has fired *)
+val has_fired : xs:Xenstore.Xs.xsh -> 'a t -> bool
+
 (** Wait for all results *)
 val all_of : 'a t list -> 'a list t
 (** Wait for any of a set of possible results *)


### PR DESCRIPTION
This will be useful when watching for several events, and multiple
fire at once. The client code can then use this to apply some
prioritisation, deciding which watch was most important.

For example an already "failed" VBD unplug can suddenly complete.
In this case we'd want to consider it completed rather than failed.

Signed-off-by: David Scott dave.scott@eu.citrix.com
