### PR TITLE
CA-79715: Allow API XMLRPC client to handle responses larger than 16MB.

### DIFF
--- a/http-svr/xmlrpc_client.ml
+++ b/http-svr/xmlrpc_client.ml
@@ -309,8 +309,6 @@ end
 module XML_protocol = Protocol(XML)
 module XMLRPC_protocol = Protocol(XMLRPC)
 
-let read_xml_rpc_response = XML_protocol.read_response
-
 
 
 


### PR DESCRIPTION
This is very similar to CA-75708, which was the same fix for the
database RPC client. Maybe in the long run we should look at whether
the two can share more code than they do at present.

Tested by:
- Quicktest.
- Creating ~60MB of VDI record data in a pool database, then calling VDI.get_all_records from python using the unix domain xapi socket on a pool slave.
