### PR TITLE
Fix Xmlrpc.a_of_response such that it doesn't call string_of_*

### DIFF
--- a/rpc-light/jsonrpc.mli
+++ b/rpc-light/jsonrpc.mli
@@ -15,11 +15,16 @@
 val to_string : Rpc.t -> string
 val of_string : string -> Rpc.t
 
+val to_a : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.t -> 'a
+val of_a : next_char:('a  -> char) -> 'a -> Rpc.t
+
 val string_of_call: Rpc.call -> string
 val call_of_string: string -> Rpc.call
 
 val string_of_response: Rpc.response -> string
-val response_of_string: string -> Rpc.response
+val a_of_response : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a
 
+val response_of_string: string -> Rpc.response
+val response_of_in_channel: in_channel -> Rpc.response
 
 

--- a/rpc-light/xmlrpc.ml
+++ b/rpc-light/xmlrpc.ml
@@ -135,7 +135,7 @@ let add_response add response =
 	else
 		Dict [ "Status", String "Failure"; "ErrorDescription", response.contents ] in
 	add "<?xml version=\"1.0\"?><methodResponse><params><param>";
-	add (to_string v);
+	to_a ~empty:(fun () -> ()) ~append:(fun _ s -> add s) v;
 	add "</param></params></methodResponse>"
 
 let string_of_response response =


### PR DESCRIPTION
Also expose json_of_response (Rpc.response -> Rpc.t) which returns
the Rpc.t encoded Jsonrpc response suitable for calling to_string on.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
