### PR TITLE
CA-94829: Bindings to the TCP keepalive settings

### DIFF
--- a/stdext/unixext.ml
+++ b/stdext/unixext.ml
@@ -559,7 +559,7 @@ let double_fork f =
 	| pid -> ignore(Unix.waitpid [] pid)
 
 external set_tcp_nodelay : Unix.file_descr -> bool -> unit = "stub_unixext_set_tcp_nodelay"
-
+external set_sock_keepalives : Unix.file_descr -> int -> int -> int -> unit = "stub_unixext_set_sock_keepalives"
 external fsync : Unix.file_descr -> unit = "stub_unixext_fsync"
 external blkgetsize64 : Unix.file_descr -> int64 = "stub_unixext_blkgetsize64"
 

--- a/stdext/unixext.mli
+++ b/stdext/unixext.mli
@@ -118,6 +118,7 @@ val spawnvp :
 val double_fork : (unit -> unit) -> unit
 external set_tcp_nodelay : Unix.file_descr -> bool -> unit
   = "stub_unixext_set_tcp_nodelay"
+external set_sock_keepalives : Unix.file_descr -> int -> int -> int -> unit = "stub_unixext_set_sock_keepalives"
 external fsync : Unix.file_descr -> unit = "stub_unixext_fsync"
 external get_max_fd : unit -> int = "stub_unixext_get_max_fd"
 external blkgetsize64 : Unix.file_descr -> int64 = "stub_unixext_blkgetsize64"

--- a/stdext/unixext_stubs.c
+++ b/stdext/unixext_stubs.c
@@ -72,6 +72,32 @@ CAMLprim value stub_unixext_get_max_fd (value unit)
 	CAMLreturn(Val_int(maxfd));
 }
 
+CAMLprim value stub_unixext_set_sock_keepalives(value fd, value count, value idle, value interval)
+{
+    CAMLparam4(fd, count, idle, interval);
+
+	int c_fd = Int_val(fd);
+	int optval;
+	socklen_t optlen=sizeof(optval);
+	
+	optval = Int_val(count);
+	if(setsockopt(c_fd, SOL_TCP, TCP_KEEPCNT, &optval, optlen) < 0) {
+	  uerror("setsockopt(TCP_KEEPCNT)", Nothing);
+	}
+	
+	optval = Int_val(idle);
+	if(setsockopt(c_fd, SOL_TCP, TCP_KEEPIDLE, &optval, optlen) < 0) {
+	  uerror("setsockopt(TCP_KEEPIDLE)", Nothing);
+	}
+	 
+	optval = Int_val(interval);
+	if(setsockopt(c_fd, SOL_TCP, TCP_KEEPINTVL, &optval, optlen) < 0) {
+	  uerror("setsockopt(TCP_KEEPINTVL)", Nothing);
+	}
+
+	CAMLreturn(Val_unit);
+}
+
 #define FDSET_OF_VALUE(v) (&(((struct fdset_t *) v)->fds))
 #define MAXFD_OF_VALUE(v) (((struct fdset_t *) v)->max)
 struct fdset_t { fd_set fds; int max; };


### PR DESCRIPTION
TAMPA-LCM: HFX-671

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
