### PR TITLE
CP-4480: Add a call to check whether PV drivers have started

### DIFF
--- a/xenctrlext/xenctrlext.ml
+++ b/xenctrlext/xenctrlext.ml
@@ -46,6 +46,8 @@ external get_max_nr_cpus: handle -> int = "stub_xenctrlext_get_max_nr_cpus"
 
 external domain_set_target: handle -> domid -> domid -> unit = "stub_xenctrlext_domain_set_target"
 
+external domain_pvcontrol_available: handle -> domid -> bool = "stub_xenctrlext_domain_pvcontrol_available"
+
 module Queueopext = struct
   open Xenstore
   include Queueop

--- a/xenctrlext/xenctrlext.mli
+++ b/xenctrlext/xenctrlext.mli
@@ -46,6 +46,8 @@ external get_max_nr_cpus: handle -> int = "stub_xenctrlext_get_max_nr_cpus"
 
 external domain_set_target: handle -> domid -> domid -> unit = "stub_xenctrlext_domain_set_target"
 
+external domain_pvcontrol_available: handle -> domid -> bool = "stub_xenctrlext_domain_pvcontrol_available"
+
 module Xsrawext : sig
   val set_target : int -> int -> Xenstore.Xs.con -> unit
 end


### PR DESCRIPTION
This is modelled after a similarly named call in libxl. We
check the CALLBACK_IRQ status for HVM domains. This requires
no changes to libxc.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
