### PR TITLE
CLEARWATER: CA-105004: Enable SO_KEEPALIVE for stunnel client

### DIFF
--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -117,7 +117,7 @@ type t = { mutable pid: pid; fd: Unix.file_descr; host: string; port: int;
 	 }
 
 let config_file verify_cert extended_diagnosis host port = 
-  let lines = ["client=yes"; "foreground=yes"; "socket = r:TCP_NODELAY=1"; Printf.sprintf "connect=%s:%d" host port ] @
+  let lines = ["client=yes"; "foreground=yes"; "socket = r:TCP_NODELAY=1"; "socket = r:SO_KEEPALIVE=1"; Printf.sprintf "connect=%s:%d" host port ] @
     (if extended_diagnosis then
        ["debug=4"]
      else


### PR DESCRIPTION
Dup of #144 for clearwater.
