### PR TITLE
Fix build id extraction with new RPM packages.

### DIFF
--- a/oclock/Makefile
+++ b/oclock/Makefile
@@ -56,7 +56,7 @@ native: oclock.cmxa liboclock.a oclock.a
 lib%.a: %_stubs.o
 	ar crs $@ $<
 dll%.so: %_stubs.o
-	$(LD) -shared -o $@ $< -lrt
+	$(CC) -shared -o $@ $< -lrt
 
 # Generic Ocaml compilation
 %.cmo:%.ml


### PR DESCRIPTION
Build id are required for making debug info properly.
However calling ld directly instead of gcc make output not contain the
build id. Fix this calling gcc instead even for linking.

Signed-off-by: Frediano Ziglio <frediano.ziglio@citrix.com>