### PR TITLE
SCTX-1649: Set SO_KEEPALIVE on server sockets

### DIFF
--- a/http-svr/http_svr.ml
+++ b/http-svr/http_svr.ml
@@ -487,6 +487,7 @@ let bind ?(listen_backlog=128) sockaddr name =
   try
     Unix.set_close_on_exec sock;
     Unix.setsockopt sock Unix.SO_REUSEADDR true;
+    Unix.setsockopt sock Unix.SO_KEEPALIVE true;
     (match sockaddr with Unix.ADDR_INET _ -> Unixext.set_tcp_nodelay sock true | _ -> ());
     Unix.bind sock sockaddr;
     Unix.listen sock listen_backlog;

--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -117,7 +117,7 @@ type t = { mutable pid: pid; fd: Unix.file_descr; host: string; port: int;
 	 }
 
 let config_file verify_cert extended_diagnosis host port = 
-  let lines = ["client=yes"; "foreground=yes"; "socket = r:TCP_NODELAY=1"; "socket = r:SO_KEEPALIVE=1"; Printf.sprintf "connect=%s:%d" host port ] @
+  let lines = ["client=yes"; "foreground=yes"; "socket = r:TCP_NODELAY=1"; "socket = r:SO_KEEPALIVE=1"; "socket = a:SO_KEEPALIVE=1"; Printf.sprintf "connect=%s:%d" host port ] @
     (if extended_diagnosis then
        ["debug=4"]
      else


### PR DESCRIPTION
This ensures that a TCP connection is cleaned up on the server, when the
connection is closed on the client without the server knowing (for example, if
a FIN packet is not sent or went missing).

This does not affect idle connections, or long-running XenAPI calls.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
