### PR TITLE
CA-89974: Live migrate fails on IPv6-preferring hosts

### DIFF
--- a/http-svr/http.mli
+++ b/http-svr/http.mli
@@ -191,6 +191,9 @@ module Url : sig
 
 	val of_string: string -> t
 
+	(** Wrap a literal IPv6 address in square brackets; otherwise pass through *)
+	val maybe_wrap_IPv6_literal : string -> string
+	
 	val to_string: t -> string
 
 	val get_uri: t -> string

--- a/stdext/stringext.ml
+++ b/stdext/stringext.ml
@@ -214,4 +214,10 @@ let sub_to_end s start =
 	let length = String.length s in
 	String.sub s start (length - start)
 
+let sub_before c s = 
+	String.sub s 0 (String.index s c)
+
+let sub_after c s =
+	sub_to_end s (String.index s c + 1)
+	
 end

--- a/stdext/stringext.mli
+++ b/stdext/stringext.mli
@@ -120,4 +120,10 @@ module String :
 
     (** a substring from the specified position to the end of the string *)
     val sub_to_end : string -> int -> string
+    
+    (** a substring from the start of the string to the first occurrence of a given character, excluding the character *)
+    val sub_before : char -> string -> string
+    
+    (** a substring from  the first occurrence of a given character to the end of the string, excluding the character *)
+    val sub_after : char -> string -> string
   end

--- a/stdext/unixext.ml
+++ b/stdext/unixext.ml
@@ -252,21 +252,19 @@ let delete_empty_file file_path =
 (** Create a new file descriptor, connect it to host:port and return it *)
 exception Host_not_found of string
 let open_connection_fd host port =
-	let s = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-	try 
-	  let he =
-	    try
-	      Unix.gethostbyname host
-	    with
-		Not_found -> raise (Host_not_found host) in
-	  if Array.length he.Unix.h_addr_list = 0
-	  then failwith (Printf.sprintf "Couldn't resolve hostname: %s" host);
-	  let ip = he.Unix.h_addr_list.(0) in
-	  let addr = Unix.ADDR_INET(ip, port) in
-	  Unix.connect s addr;
-	  s
-	with e -> Unix.close s; raise e
-
+	let open Unix in
+	let addrinfo = getaddrinfo host (string_of_int port) [AI_SOCKTYPE SOCK_STREAM] in
+	match addrinfo with 
+	| [] -> 
+		failwith (Printf.sprintf "Couldn't resolve hostname: %s" host)
+	| ai :: _ ->
+		let s = socket ai.ai_family ai.ai_socktype 0 in
+		try
+			connect s ai.ai_addr;
+			s
+		with e ->
+			close s;
+			raise e
 
 let open_connection_unix_fd filename =
 	let s = Unix.socket Unix.PF_UNIX Unix.SOCK_STREAM 0 in
@@ -676,6 +674,13 @@ type statvfs_t = {
 }
 
 external statvfs : string -> statvfs_t = "stub_statvfs"
+
+(** Returns Some Unix.PF_INET or Some Unix.PF_INET6 if passed a valid IP address, otherwise returns None. *)
+let domain_of_addr str =
+	try
+		let addr = Unix.inet_addr_of_string str in
+		Some (Unix.domain_of_sockaddr (Unix.ADDR_INET (addr, 1)))
+	with _ -> None
 
 module Direct = struct
 	type t = Unix.file_descr

--- a/stdext/unixext.mli
+++ b/stdext/unixext.mli
@@ -167,6 +167,9 @@ type statvfs_t = {
 
 val statvfs : string -> statvfs_t
 
+(** Returns Some Unix.PF_INET or Some Unix.PF_INET6 if passed a valid IP address, otherwise returns None. *)
+val domain_of_addr : string -> Unix.socket_domain option
+
 module Direct : sig
 	(** Perform I/O in O_DIRECT mode using 4KiB page-aligned buffers *)
 


### PR DESCRIPTION
Make HTTP server understand URLs containing literal IPv6 addresses.
A related commit to xen-api makes the client embed literal IPv6 addresses
in URLs correctly.
- Parse IPv6 literals wrapped in square brackets in URLs
- Wrap IPv6 literals in square brackets when creating URLs
- Copy 'Helpers.validate_ip_address' from xapi/helpers.ml in xen-api
  to stdext/unixext.ml and rename it to 'domain_of_addr';  a separate
  commit to xen-api will remove the original 'validate_ip_address'
