### PR TITLE
CP-8639: Enable core dumps

### DIFF
--- a/forking_executioner/init.d-fe
+++ b/forking_executioner/init.d-fe
@@ -24,6 +24,9 @@ SUBSYS_FILE="/var/lock/subsys/fe"
 # Source function library.
 . /etc/init.d/functions
 
+# Enable core dumping
+ulimit -c unlimited
+
 start() {
 	echo -n $"Starting the fork/exec daemon: "
 	


### PR DESCRIPTION
Call ulimit -c unlimited in the fe daemon's init script, so core files can be written.

See also https://github.com/xapi-project/xen-api/pull/1777
