### PR TITLE
[CLEARWATER] Changes to support Contrail Vrouter as a networking option

### DIFF
--- a/netdev/netdev.mli
+++ b/netdev/netdev.mli
@@ -17,6 +17,7 @@
 type kind = 
     Bridge  (** Linux Bridge based networking *)
   | Vswitch (** Vswitch based networking *)
+  | Vrouter (** Vrouter based networking *)
 
 (** Possible operations on each network backend type. *)
 type network_ops = {


### PR DESCRIPTION
Changes to support Contrail Vrouter as a networking option in the netdev library. A module VRouter is created which handles all the networking ops.