### PR TITLE
HFX-1149: Pick SCTX-1766: Configurable timeout for stunnel from creedence (7541b5a) to clearwater-sp1-lcm

### DIFF
--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -31,6 +31,8 @@ let new_stunnel_path = "/usr/sbin/stunnelng"
 let cached_stunnel_path = ref None
 let stunnel_logger = ref ignore
 
+let timeoutidle = ref None
+
 let init_stunnel_path () =
 	try cached_stunnel_path := Some (Unix.getenv "XE_STUNNEL")
 	with Not_found ->
@@ -117,7 +119,9 @@ type t = { mutable pid: pid; fd: Unix.file_descr; host: string; port: int;
 	 }
 
 let config_file verify_cert extended_diagnosis host port = 
-  let lines = ["client=yes"; "foreground=yes"; "socket = r:TCP_NODELAY=1"; "socket = r:SO_KEEPALIVE=1"; "socket = a:SO_KEEPALIVE=1"; Printf.sprintf "connect=%s:%d" host port ] @
+  let lines = ["client=yes"; "foreground=yes"; "socket = r:TCP_NODELAY=1"; "socket = r:SO_KEEPALIVE=1"; "socket = a:SO_KEEPALIVE=1";
+    (match !timeoutidle with None -> "" | Some x -> Printf.sprintf "TIMEOUTidle = %d" x);
+    Printf.sprintf "connect=%s:%d" host port ] @
     (if extended_diagnosis then
        ["debug=4"]
      else

--- a/stunnel/stunnel.mli
+++ b/stunnel/stunnel.mli
@@ -19,6 +19,8 @@ exception Stunnel_verify_error of string
 val certificate_path : string
 val crl_path : string
 
+val timeoutidle : int option ref
+
 type pid =
   | StdFork of int (** we forked and exec'ed. This is the pid *)
   | FEFork of Forkhelpers.pidty (** the forkhelpers module did it for us. *)


### PR DESCRIPTION
Imported from xen-api-libs-transitional.git
9e46fa5d7ae9c4d3f10e58fce968bcee91e5bbbc

Signed-off-by: Akshay akshay.ramani@citrix.com
Imported-by: John Else john.else@citrix.com

Resolve Merge Conflicts for clearwater-sp1-lcm
    stunnel/stunnel.ml

Signed-off-by: Zheng Chai zheng.chai@citrix.com
